### PR TITLE
Modify ra.aid Agent to Integrate Expert Model from OpenRouter 

Fixes #48

### DIFF
--- a/src/agents/raaid.py
+++ b/src/agents/raaid.py
@@ -8,6 +8,8 @@ def get_container_kwargs(
     repo_directory: str,
     solver_command: str,
     model_name: ModelName,
+    expert_provider: str = "openrouter",
+    expert_model: str = "openrouter/deepseek/deepseek-r1",
 ) -> str:
     escaped_solver_command = solver_command.replace("'", "'\"'\"'")
     entrypoint = [
@@ -15,13 +17,14 @@ def get_container_kwargs(
         "-c",
         (
             "source /venv/bin/activate && "
-            f"ra-aid -m '{escaped_solver_command}' --provider openai-compatible --model {model_name.value} --cowboy-mode"  # noqa: E501
+            f"ra-aid -m '{escaped_solver_command}' --provider openai-compatible --model {model_name.value} --expert-provider {expert_provider} --expert-model {expert_model} --cowboy-mode"  # noqa: E501
         ).strip(),
     ]
 
     env_vars = {
         "OPENAI_API_BASE": SETTINGS.litellm_docker_internal_api_base,
         "OPENAI_API_KEY": SETTINGS.litellm_api_key,
+        "OPENROUTER_API_KEY": os.environ.get("OPENROUTER_API_KEY", ""),
     }
 
     volumes = {


### PR DESCRIPTION
# Pull Request Description

## Overview
This pull request implements modifications to the `ra.aid` agent, enabling it to utilize the `openrouter/deepseek/deepseek-r1` model as an expert model. The changes align with the specifications outlined in issue [#48](https://api.github.com/repos/GroupLang/minimal-provider-agent-market/issues/48) and are designed to enhance the agent's functionality while maintaining its existing behavior.

## Changes Made
1. **New Parameters Introduced:**
   - **`--expert-provider`**: Added with a default value of `"openrouter"`.
   - **`--expert-model`**: Added with a default value of `"openrouter/deepseek/deepseek-r1"`.

2. **Command Modification:**
   - The `ra-aid` command has been updated to accommodate the new parameters. The updated command structure is as follows:
     ```
     ra-aid -m "Your task" --expert-provider openrouter --expert-model openrouter/deepseek/deepseek-r1
     ```

3. **Environment Variable Handling:**
   - Introduced the `OPENROUTER_API_KEY` environment variable, which must be set for the expert model to function correctly. If not set, it defaults to an empty string.

## Impact
These modifications allow users to seamlessly integrate the expert model into their existing workflows without disrupting current operations. The ability to specify the expert model while keeping prior functionality intact addresses the requirements specified in the issue.

**Fixes #48**

Please review these changes, and let me know if there are any questions or further enhancements needed. Thank you!