### PR TITLE
"Downgrade ra-aid Package Version in Dockerfile to Fix Installation Error (Fixes #53)"

### DIFF
--- a/src/agents/raaid.Dockerfile
+++ b/src/agents/raaid.Dockerfile
@@ -5,4 +5,4 @@ SHELL ["/bin/bash", "-c"]
 RUN apt-get update && \
     apt-get install -y ripgrep && \
     . /venv/bin/activate && \
-    pip install ra-aid
+    pip install ra-aid==0.13.2


### PR DESCRIPTION
## Pull Request Description

### Summary

This pull request addresses issue #53, which involves downgrading the `ra-aid` package to resolve installation errors encountered with the latest version. The updates focus on the `raaid.Dockerfile`, where the package version for `ra-aid` has been pinned to a stable version to ensure compatibility and prevent errors during the Docker image build process.

### Details of Changes

1. **Issue Context**: The step to install `ra-aid` in the Docker image was failing due to problems associated with the latest package release.

2. **Version Selection**: After reviewing the available versions of `ra-aid`, it was determined that version `0.14.1` was causing issues. Therefore, the stable version `0.13.2` has been chosen as a more reliable alternative.

3. **Dockerfile Adjustments**: The installation command in the `raaid.Dockerfile` has been updated to explicitly install `ra-aid` version `0.13.2`. The updated section of the Dockerfile is as follows:

   ```dockerfile
   FROM paulgauthier/aider

   USER root
   SHELL ["/bin/bash", "-c"]
   RUN apt-get update && \
       apt-get install -y ripgrep && \
       . /venv/bin/activate && \
       pip install ra-aid==0.13.2
   ```

### Impact

- This change should resolve the installation errors when building the Docker image.
- Pinning the package version helps maintain consistent behavior across deployments and environments.

### Conclusion

The modifications made in this pull request effectively resolve the issues identified in #53. By downgrading the `ra-aid` package to version `0.13.2`, the installation process within the Docker environment is expected to succeed without errors. 

Please review the changes, and feel free to provide any feedback or request further modifications. 

**Fixes #53**